### PR TITLE
chore(ci-publish): support provenance for monorepo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
 name: Publish to NPM
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - '**@*'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,6 +17,7 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish --provenance --access public
+      - name: Get the name of the package
+        run : npm publish --workspace=\"packages/${GITHUB_REF_NAME##*@}\"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} --provenance --access public


### PR DESCRIPTION
Tags will be `vX.X.X@packagename`