### PR TITLE
chore: bump 1.0.0 → 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "nodejs-loaders",
   "author": "Jacob Smith",
   "license": "ISC",


### PR DESCRIPTION
Prepare the release of `1.1.0` before monorepo.
We only bump the minor cause changing of parser allow nested css. But it's shouldn't introduce breaking change.