### PR TITLE
chore(readme): update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nodejs Loaders
 
-<img src="./logo.svg" height="100" width="100" alt="" />
+<img src="https://raw.githubusercontent.com/JakobJingleheimer/nodejs-loaders/refs/heads/main/logo.svg" height="100" width="100" alt="@node.js loaders logo" />
 
 ![coverage](https://img.shields.io/coverallsCoverage/github/JakobJingleheimer/nodejs-loaders)
 ![tests](https://github.com/JakobJingleheimer/nodejs-loaders/actions/workflows/ci.yml/badge.svg)

--- a/packages/alias/README.md
+++ b/packages/alias/README.md
@@ -1,6 +1,6 @@
 # Nodejs Loaders: Alias
 
-<img src="../../logo.svg" height="100" width="100" alt="" />
+<img src="https://raw.githubusercontent.com/JakobJingleheimer/nodejs-loaders/refs/heads/main/logo.svg" height="100" width="100" alt="@node.js loaders logo" />
 
 [![npm version](https://img.shields.io/npm/v/nodejs-loaders/alias.svg)](https://www.npmjs.com/package/nodejs-loaders/alias)
 ![size](https://img.shields.io/github/languages/code-size/JakobJingleheimer/nodejs-loaders/alias)

--- a/packages/css-module/README.md
+++ b/packages/css-module/README.md
@@ -1,6 +1,6 @@
 # Nodejs Loaders: CSS Module
 
-<img src="../../logo.svg" height="100" width="100" alt="" />
+<img src="https://raw.githubusercontent.com/JakobJingleheimer/nodejs-loaders/refs/heads/main/logo.svg" height="100" width="100" alt="@node.js loaders logo" />
 
 [![npm version](https://img.shields.io/npm/v/nodejs-loaders/media.svg)](https://www.npmjs.com/package/nodejs-loaders/css-module)
 ![size](https://img.shields.io/github/languages/code-size/JakobJingleheimer/nodejs-loaders/css-module)

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -1,6 +1,6 @@
 # Nodejs Loaders: Media
 
-<img src="../../logo.svg" height="100" width="100" alt="" />
+<img src="https://raw.githubusercontent.com/JakobJingleheimer/nodejs-loaders/refs/heads/main/logo.svg" height="100" width="100" alt="@node.js loaders logo" />
 
 [![npm version](https://img.shields.io/npm/v/nodejs-loaders/media.svg)](https://www.npmjs.com/package/nodejs-loaders/media)
 ![size](https://img.shields.io/github/languages/code-size/JakobJingleheimer/nodejs-loaders/media)

--- a/packages/mismatched-format/README.md
+++ b/packages/mismatched-format/README.md
@@ -1,6 +1,6 @@
 # Nodejs Loaders: Mismatched format
 
-<img src="../../logo.svg" height="100" width="100" alt="" />
+<img src="https://raw.githubusercontent.com/JakobJingleheimer/nodejs-loaders/refs/heads/main/logo.svg" height="100" width="100" alt="@node.js loaders logo" />
 
 [![npm version](https://img.shields.io/npm/v/nodejs-loaders/mismatched-format.svg)](https://www.npmjs.com/package/nodejs-loaders/mismatched-format)
 ![size](https://img.shields.io/github/languages/code-size/JakobJingleheimer/nodejs-loaders/mismatched-format)

--- a/packages/svgx/README.md
+++ b/packages/svgx/README.md
@@ -1,6 +1,6 @@
 # Nodejs Loaders: SVGX
 
-<img src="../../logo.svg" height="100" width="100" alt="" />
+<img src="https://raw.githubusercontent.com/JakobJingleheimer/nodejs-loaders/refs/heads/main/logo.svg" height="100" width="100" alt="@node.js loaders logo" />
 
 [![npm version](https://img.shields.io/npm/v/nodejs-loaders/svgx.svg)](https://www.npmjs.com/package/nodejs-loaders/svgx)
 ![size](https://img.shields.io/github/languages/code-size/JakobJingleheimer/nodejs-loaders/svgx)

--- a/packages/text/README.md
+++ b/packages/text/README.md
@@ -1,6 +1,6 @@
 # Nodejs Loaders: Text
 
-<img src="../../logo.svg" height="100" width="100" alt="" />
+<img src="https://raw.githubusercontent.com/JakobJingleheimer/nodejs-loaders/refs/heads/main/logo.svg" height="100" width="100" alt="@node.js loaders logo" />
 
 [![npm version](https://img.shields.io/npm/v/nodejs-loaders/text.svg)](https://www.npmjs.com/package/nodejs-loaders/text)
 ![size](https://img.shields.io/github/languages/code-size/JakobJingleheimer/nodejs-loaders/text)

--- a/packages/tsx/README.md
+++ b/packages/tsx/README.md
@@ -1,6 +1,6 @@
 # Nodejs Loaders: JSX / TSX
 
-<img src="../../logo.svg" height="100" width="100" alt="" />
+<img src="https://raw.githubusercontent.com/JakobJingleheimer/nodejs-loaders/refs/heads/main/logo.svg" height="100" width="100" alt="@node.js loaders logo" />
 
 [![npm version](https://img.shields.io/npm/v/nodejs-loaders/tsx.svg)](https://www.npmjs.com/package/nodejs-loaders/tsx)
 ![size](https://img.shields.io/github/languages/code-size/JakobJingleheimer/nodejs-loaders/tsx)


### PR DESCRIPTION
Thanks to this pr, the readme uses gh raw because at the moment if we publish, the npm page won't display the logo.