### PR TITLE
chore(deps, tsx): temporarily remove support for node below v23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [23.x, 22.x, 20.x]
+        node:
+					- version:
+						- 23.x
+						- 22.x
+						- 20.x
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       fail-fast: false # prevent a failure in other versions run cancelling others
 
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node.version }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node.version }}
         cache: 'npm'
     - name: npm clean install
       run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,16 @@ jobs:
 
     strategy:
       matrix:
-        node:
-					- version:
-						- 23.x
-						- 22.x
-						- 20.x
+        node-version: [23.x, 22.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       fail-fast: false # prevent a failure in other versions run cancelling others
 
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node.version }}
+    - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node.version }}
+        node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - name: npm clean install
       run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,35 +15,37 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [23.x, 22.x, 20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+				node:
+          - version: 23.x
+          - version: 22.x
+          # glob is not backported below 22.x
       fail-fast: false # prevent a failure in other versions run cancelling others
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - name: npm clean install
-      run: npm ci
-    - run: npm test
-    - name: Publish coverage to Coveralls ${{ matrix.test_number }}
-      uses: coverallsapp/github-action@v2
-      with:
-        flag-name: run-${{ join(matrix.*, '-') }}
-        file: ./coverage.lcov
-        format: lcov
-        parallel: true
+			- uses: actions/checkout@v4
+			- name: Use Node.js ${{ matrix.node.version }}
+				uses: actions/setup-node@v4
+				with:
+					node-version: ${{ matrix.node.version }}
+					cache: 'npm'
+			- name: npm clean install
+				run: npm ci
+			- run: npm test
+			- name: Publish coverage to Coveralls ${{ matrix.test_number }}
+				uses: coverallsapp/github-action@v2
+				with:
+					flag-name: run-${{ join(matrix.*, '-') }}
+					file: ./coverage.lcov
+					format: lcov
+					parallel: true
 
   finish:
     needs: test
     if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel-finished: true
-        carryforward: "run-1,run-2"
+			- name: Coveralls Finished
+				uses: coverallsapp/github-action@v2
+				with:
+					parallel-finished: true
+					carryforward: "run-1,run-2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,37 +15,37 @@ jobs:
 
     strategy:
       matrix:
-				node:
+        node:
           - version: 23.x
           - version: 22.x
           # glob is not backported below 22.x
       fail-fast: false # prevent a failure in other versions run cancelling others
 
     steps:
-			- uses: actions/checkout@v4
-			- name: Use Node.js ${{ matrix.node.version }}
-				uses: actions/setup-node@v4
-				with:
-					node-version: ${{ matrix.node.version }}
-					cache: 'npm'
-			- name: npm clean install
-				run: npm ci
-			- run: npm test
-			- name: Publish coverage to Coveralls ${{ matrix.test_number }}
-				uses: coverallsapp/github-action@v2
-				with:
-					flag-name: run-${{ join(matrix.*, '-') }}
-					file: ./coverage.lcov
-					format: lcov
-					parallel: true
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node.version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node.version }}
+          cache: 'npm'
+      - name: npm clean install
+        run: npm ci
+      - run: npm test
+      - name: Publish coverage to Coveralls ${{ matrix.test_number }}
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: run-${{ join(matrix.*, '-') }}
+          file: ./coverage.lcov
+          format: lcov
+          parallel: true
 
   finish:
     needs: test
     if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
-			- name: Coveralls Finished
-				uses: coverallsapp/github-action@v2
-				with:
-					parallel-finished: true
-					carryforward: "run-1,run-2"
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
+          carryforward: "run-1,run-2"

--- a/packages/tsx/package.json
+++ b/packages/tsx/package.json
@@ -15,7 +15,7 @@
 		"typescript"
 	],
 	"engines": {
-		"node": "^20.19 || ^22.12 || ^23.2"
+		"node": "^23.2 || ^22.13"
 	},
 	"dependencies": {
 		"@nodejs-loaders/parse-filename": "1.0.0"

--- a/packages/tsx/tsx.spec.mjs
+++ b/packages/tsx/tsx.spec.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import process from 'node:process';
 import { describe, it, mock } from 'node:test';
 
 import { assertSuffixedSpecifiers } from '../../fixtures/assert-suffixed-specifiers.fixture.mjs';
@@ -8,6 +9,7 @@ import { nextResolve } from '../../fixtures/nextResolve.fixture.mjs';
 import { jsxExts, tsxExts, load, resolve } from './tsx.mjs';
 
 
+if (process.version.startsWith('v23')) {
 describe('JSX & TypeScript loader', { concurrency: true }, () => {
 	describe('resolve', () => {
 		it('should ignore files that aren’t text', async () => {
@@ -119,3 +121,4 @@ describe('JSX & TypeScript loader', { concurrency: true }, () => {
 		});
 	});
 });
+}

--- a/packages/tsx/tsx.spec.mjs
+++ b/packages/tsx/tsx.spec.mjs
@@ -1,124 +1,122 @@
-import assert from 'node:assert/strict';
-import process from 'node:process';
-import { describe, it, mock } from 'node:test';
-
-import { assertSuffixedSpecifiers } from '../../fixtures/assert-suffixed-specifiers.fixture.mjs';
-import { nextLoad } from '../../fixtures/nextLoad.fixture.mjs';
-import { nextResolve } from '../../fixtures/nextResolve.fixture.mjs';
-
-import { jsxExts, tsxExts, load, resolve } from './tsx.mjs';
-
-
 if (process.version.startsWith('v23')) {
-describe('JSX & TypeScript loader', { concurrency: true }, () => {
-	describe('resolve', () => {
-		it('should ignore files that aren’t text', async () => {
-			const result = await resolve('./fixture.ext', {}, nextResolve);
+	const assert = await import('node:assert/strict');
+	const { describe, it, mock } = await import('node:test');
 
-			assert.deepEqual(result, {
-				format: 'unknown',
-				url: './fixture.ext',
+	const { assertSuffixedSpecifiers } = await import('../../fixtures/assert-suffixed-specifiers.fixture.mjs');
+	const { nextLoad } = await import('../../fixtures/nextLoad.fixture.mjs');
+	const { nextResolve } = await import('../../fixtures/nextResolve.fixture.mjs');
+
+	const { jsxExts, tsxExts, load, resolve } = await import('./tsx.mjs');
+
+	describe('JSX & TypeScript loader', { concurrency: true }, () => {
+		describe('resolve', () => {
+			it('should ignore files that aren’t text', async () => {
+				const result = await resolve('./fixture.ext', {}, nextResolve);
+
+				assert.deepEqual(result, {
+					format: 'unknown',
+					url: './fixture.ext',
+				});
+			});
+
+			it('should recognise JSX files', async () => {
+				for (const ext of jsxExts) {
+					const fileUrl = import.meta.resolve(`./fixture${ext}`);
+					const result = await resolve(fileUrl, {}, nextResolve);
+
+					assert.deepEqual(result, {
+						format: 'jsx',
+						url: fileUrl,
+					});
+				}
+			});
+
+			it('should recognise TypeScript files', async () => {
+				for (const ext of tsxExts) {
+					const fileUrl = import.meta.resolve(`./fixture${ext}`);
+					const result = await resolve(fileUrl, {}, nextResolve);
+
+					assert.deepEqual(result, {
+						format: 'tsx',
+						url: fileUrl,
+					});
+				}
+			});
+
+			it('should handle specifiers with appending data', async () => {
+				for (const ext of jsxExts) await assertSuffixedSpecifiers(resolve, `./fixture${ext}`, 'jsx');
+				for (const ext of tsxExts) await assertSuffixedSpecifiers(resolve, `./fixture${ext}`, 'tsx');
 			});
 		});
 
-		it('should recognise JSX files', async () => {
-			for (const ext of jsxExts) {
-				const fileUrl = import.meta.resolve(`./fixture${ext}`);
-				const result = await resolve(fileUrl, {}, nextResolve);
+		describe('load', () => {
+			const parentURL = import.meta.url;
+
+			it('should ignore files that aren’t J|TSX', async () => {
+				const result = await load(import.meta.resolve('../../fixtures/fixture.ext'), {}, nextLoad);
 
 				assert.deepEqual(result, {
-					format: 'jsx',
-					url: fileUrl,
+					format: 'unknown',
+					source: '',
 				});
-			}
-		});
+			});
 
-		it('should recognise TypeScript files', async () => {
-			for (const ext of tsxExts) {
-				const fileUrl = import.meta.resolve(`./fixture${ext}`);
-				const result = await resolve(fileUrl, {}, nextResolve);
+			// This verifies that esbuild.config.mjs is being loaded correctly because the one in this repo
+			// disables minification, but the loader's default config enables it.
+			const transpiled = [
+				'import { jsxDEV } from "react/jsx-dev-runtime";',
+				'export function Greet({ name }) {',
+				'  return /* @__PURE__ */ jsxDEV("h1", { children: [',
+				'    "Hello ",',
+				'    name',
+				'  ] }, void 0, true, {',
+				'    fileName: "<stdin>",',
+				'    lineNumber: 2,',
+				'    columnNumber: 10',
+				'  }, this);',
+				'}',
+				'Greet.displayName = "Greet";',
+				'', //EoF
+			].join('\n');
 
-				assert.deepEqual(result, {
-					format: 'tsx',
-					url: fileUrl,
-				});
-			}
-		});
+			it('should transpile JSX', async () => {
+				const fileUrl = import.meta.resolve('./fixture.jsx');
+				const result = await load(fileUrl, { format: 'jsx', parentURL }, nextLoad);
 
-		it('should handle specifiers with appending data', async () => {
-			for (const ext of jsxExts) await assertSuffixedSpecifiers(resolve, `./fixture${ext}`, 'jsx');
-			for (const ext of tsxExts) await assertSuffixedSpecifiers(resolve, `./fixture${ext}`, 'tsx');
-		});
-	});
+				assert.equal(result.format, 'module');
+				assert.equal(result.source, transpiled);
+			});
 
-	describe('load', () => {
-		const parentURL = import.meta.url;
+			it('should transpile TSX', async () => {
+				const fileUrl = import.meta.resolve('./fixture.tsx');
+				const result = await load(fileUrl, { format: 'tsx', parentURL }, nextLoad);
 
-		it('should ignore files that aren’t J|TSX', async () => {
-			const result = await load(import.meta.resolve('../../fixtures/fixture.ext'), {}, nextLoad);
+				assert.equal(result.format, 'module');
+				assert.equal(result.source, transpiled);
+			});
 
-			assert.deepEqual(result, {
-				format: 'unknown',
-				source: '',
+			it('should log transpile errors', async () => {
+				const badJSX = `const Foo (a) => (<div />)`; // missing `=`
+				const orig_consoleError = console.error;
+
+				const consoleErr = globalThis.console.error = mock.fn();
+
+				await load(
+					'whatever.tsx',
+					{
+						format: 'tsx',
+						parentURL: import.meta.url,
+					},
+					async () => ({ source: badJSX }),
+				);
+
+				const errLog = consoleErr.mock.calls[0].arguments[0];
+
+				assert.match(errLog, /TranspileError/);
+				assert.match(errLog, /found "\("/);
+
+				globalThis.console.error = orig_consoleError;
 			});
 		});
-
-		// This verifies that esbuild.config.mjs is being loaded correctly because the one in this repo
-		// disables minification, but the loader's default config enables it.
-		const transpiled = [
-			'import { jsxDEV } from "react/jsx-dev-runtime";',
-			'export function Greet({ name }) {',
-			'  return /* @__PURE__ */ jsxDEV("h1", { children: [',
-			'    "Hello ",',
-			'    name',
-			'  ] }, void 0, true, {',
-			'    fileName: "<stdin>",',
-			'    lineNumber: 2,',
-			'    columnNumber: 10',
-			'  }, this);',
-			'}',
-			'Greet.displayName = "Greet";',
-			'', //EoF
-		].join('\n');
-
-		it('should transpile JSX', async () => {
-			const fileUrl = import.meta.resolve('./fixture.jsx');
-			const result = await load(fileUrl, { format: 'jsx', parentURL }, nextLoad);
-
-			assert.equal(result.format, 'module');
-			assert.equal(result.source, transpiled);
-		});
-
-		it('should transpile TSX', async () => {
-			const fileUrl = import.meta.resolve('./fixture.tsx');
-			const result = await load(fileUrl, { format: 'tsx', parentURL }, nextLoad);
-
-			assert.equal(result.format, 'module');
-			assert.equal(result.source, transpiled);
-		});
-
-		it('should log transpile errors', async () => {
-			const badJSX = `const Foo (a) => (<div />)`; // missing `=`
-			const orig_consoleError = console.error;
-
-			const consoleErr = globalThis.console.error = mock.fn();
-
-			await load(
-				'whatever.tsx',
-				{
-					format: 'tsx',
-					parentURL: import.meta.url,
-				},
-				async () => ({ source: badJSX }),
-			);
-
-			const errLog = consoleErr.mock.calls[0].arguments[0];
-
-			assert.match(errLog, /TranspileError/);
-			assert.match(errLog, /found "\("/);
-
-			globalThis.console.error = orig_consoleError;
-		});
 	});
-});
 }


### PR DESCRIPTION
TSX loader requires `module.findPackageJSON`, which is not yet backported below 23.x (https://github.com/nodejs/node/pull/56074).

When it is backported, we'll release a patch of TSX loader to restore support.